### PR TITLE
M3-426 FCM 전체 알림 최적화

### DIFF
--- a/src/main/java/com/m3pro/groundflipbebatch/repository/FcmTokenRepository.java
+++ b/src/main/java/com/m3pro/groundflipbebatch/repository/FcmTokenRepository.java
@@ -1,5 +1,6 @@
 package com.m3pro.groundflipbebatch.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -70,4 +71,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 	Optional<FcmToken> findTokenForServiceNotifications(@Param("user_id") Long userId);
 
 	void deleteByUser(User user);
+
+	void deleteByTokenIn(Collection<String> token);
 }

--- a/src/main/java/com/m3pro/groundflipbebatch/service/FcmService.java
+++ b/src/main/java/com/m3pro/groundflipbebatch/service/FcmService.java
@@ -27,9 +27,11 @@ import lombok.extern.slf4j.Slf4j;
 public class FcmService {
 	private final FirebaseMessaging firebaseMessaging;
 	private final FcmTokenRepository fcmTokenRepository;
+	private final FcmTokenService fcmTokenService;
+	private static final int BATCH_SIZE = 100;
 
 	public void sendNotificationToAllUsers(String title, String body, PushTarget target, PushKind kind) {
-		List<FcmToken> fcmTokens = findFcmTokens(target, kind);
+		List<FcmToken> fcmTokens = fcmTokenService.findFcmTokens(target, kind);
 
 		sendNotificationToUsers(title, body, fcmTokens);
 	}

--- a/src/main/java/com/m3pro/groundflipbebatch/service/FcmService.java
+++ b/src/main/java/com/m3pro/groundflipbebatch/service/FcmService.java
@@ -96,27 +96,6 @@ public class FcmService {
 		return batches;
 	}
 
-	public void sendNotificationToAndroidUsers(String title, String body) {
-		List<FcmToken> fcmTokens = fcmTokenRepository.findAllAndroidTokensForStepNotification();
-		List<Long> failedTokensId = new ArrayList<>();
-
-		fcmTokens.forEach(fcmToken -> {
-			try {
-				log.warn("success send notification to user [{}]: tokenId = {}", fcmToken.getUser().getId(), fcmToken.getId());
-				sendMessage(title, body, fcmToken.getToken());
-			} catch(FirebaseMessagingException e) {
-				if (isInvalidTokenError(e)) {
-					failedTokensId.add(fcmToken.getId());
-					log.warn("Failed to send notification to [{}]: {}", fcmToken.getUser().getId(), fcmToken.getToken());
-				}
-			}
-		});
-
-		if (!failedTokensId.isEmpty()) {
-			fcmTokenRepository.deleteAllById(failedTokensId);
-		}
-	}
-
 	public void sendNotificationToUser(String title, String body, Long userId) {
 		Optional<FcmToken> fcmToken = fcmTokenRepository.findTokenForServiceNotifications(userId);
 		if (fcmToken.isPresent()) {

--- a/src/main/java/com/m3pro/groundflipbebatch/service/FcmService.java
+++ b/src/main/java/com/m3pro/groundflipbebatch/service/FcmService.java
@@ -48,7 +48,7 @@ public class FcmService {
 			MulticastMessage multicastMessage = createMulticastMessage(title, body, batch);
 
 			try {
-				BatchResponse batchResponse = firebaseMessaging.sendEachForMulticast(multicastMessage, true);
+				BatchResponse batchResponse = firebaseMessaging.sendEachForMulticast(multicastMessage);
 				invalidTokens.addAll(extractInvalidTokens(batch, batchResponse));
 			} catch (FirebaseMessagingException e) {
 				log.error("{} {}", e.getMessage(), e.getStackTrace());

--- a/src/main/java/com/m3pro/groundflipbebatch/service/FcmTokenService.java
+++ b/src/main/java/com/m3pro/groundflipbebatch/service/FcmTokenService.java
@@ -1,0 +1,49 @@
+package com.m3pro.groundflipbebatch.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.m3pro.groundflipbebatch.entity.FcmToken;
+import com.m3pro.groundflipbebatch.enums.PushKind;
+import com.m3pro.groundflipbebatch.enums.PushTarget;
+import com.m3pro.groundflipbebatch.repository.FcmTokenRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmTokenService {
+	private final FcmTokenRepository fcmTokenRepository;
+
+	public List<FcmToken> findFcmTokens(PushTarget target, PushKind kind) {
+		List<FcmToken> fcmTokens;
+		if (kind == PushKind.SERVICE) {
+			if (target == PushTarget.ALL) {
+				fcmTokens = fcmTokenRepository.findAllTokensForServiceNotifications();
+			} else if (target == PushTarget.ANDROID) {
+				fcmTokens = fcmTokenRepository.findAllAndroidTokensForServiceNotification();
+			} else {
+				fcmTokens = fcmTokenRepository.findAllIOSTokensForServiceNotification();
+			}
+		} else {
+			if (target == PushTarget.ALL) {
+				fcmTokens = fcmTokenRepository.findAllTokensForMarketingNotifications();
+			} else if (target == PushTarget.ANDROID) {
+				fcmTokens = fcmTokenRepository.findAllAndroidTokensForMarketingNotification();
+			} else {
+				fcmTokens = fcmTokenRepository.findAllIOSTokensForMarketingNotification();
+			}
+		}
+
+		return fcmTokens;
+	}
+
+	@Transactional
+	public void removeAllTokens(List<String> tokens) {
+		fcmTokenRepository.deleteByTokenIn(tokens);
+	}
+}

--- a/src/main/java/com/m3pro/groundflipbebatch/service/NotificationManager.java
+++ b/src/main/java/com/m3pro/groundflipbebatch/service/NotificationManager.java
@@ -1,0 +1,82 @@
+package com.m3pro.groundflipbebatch.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.m3pro.groundflipbebatch.entity.Achievement;
+import com.m3pro.groundflipbebatch.entity.Notification;
+import com.m3pro.groundflipbebatch.entity.User;
+import com.m3pro.groundflipbebatch.entity.UserNotification;
+import com.m3pro.groundflipbebatch.enums.NotificationCategory;
+import com.m3pro.groundflipbebatch.repository.NotificationRepository;
+import com.m3pro.groundflipbebatch.repository.UserNotificationRepository;
+import com.m3pro.groundflipbebatch.repository.UserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationManager {
+	private final UserNotificationRepository userNotificationRepository;
+	private final NotificationRepository notificationRepository;
+	private final UserRepository userRepository;
+	private final AnnouncementService announcementService;
+
+	@Transactional
+	public void createAchievementNotification(Long userId, Achievement achievement) {
+		Notification notification = createNotification(achievement.getName() + " 획득!", NotificationCategory.ACHIEVEMENT, achievement.getId());
+		userNotificationRepository.save(UserNotification.builder()
+			.userId(userId)
+			.notification(notification)
+			.build());
+	}
+
+	@Transactional
+	public void createAnnouncementNotification(String title, String contents) {
+		Long announcementId = announcementService.createAnnouncement(title, contents);
+		Notification notification = createNotification(title, NotificationCategory.ANNOUNCEMENT, announcementId);
+		createNotificationToAllUsers(notification);
+	}
+
+	private Notification createNotification(String title, NotificationCategory category, Long contentId) {
+		return notificationRepository.save(Notification.builder()
+			.title(title)
+			.category(category.getCategoryName())
+			.categoryId(category.getCategoryId())
+			.contentId(contentId)
+			.build()
+		);
+	}
+
+	private void createNotificationToAllUsers(Notification notification) {
+		int page = 0;
+		int pageSize = 500;
+
+		Pageable pageable = PageRequest.of(page, pageSize);
+		Page<User> userPage;
+		do {
+			userPage = userRepository.findAll(pageable);
+			List<UserNotification> userNotifications = userPage.getContent().stream()
+				.map(user -> UserNotification.builder()
+					.notification(notification)
+					.userId(user.getId())
+					.build())
+				.collect(Collectors.toList());
+
+			userNotificationRepository.saveAll(userNotifications);
+			userNotificationRepository.flush(); // 캐시 초기화
+
+			pageable = pageable.next(); // 다음 페이지로 이동
+		} while (userPage.hasNext());
+	}
+
+
+}

--- a/src/main/java/com/m3pro/groundflipbebatch/service/NotificationService.java
+++ b/src/main/java/com/m3pro/groundflipbebatch/service/NotificationService.java
@@ -1,26 +1,11 @@
 package com.m3pro.groundflipbebatch.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.m3pro.groundflipbebatch.entity.Achievement;
-import com.m3pro.groundflipbebatch.entity.Notification;
-import com.m3pro.groundflipbebatch.entity.User;
-import com.m3pro.groundflipbebatch.entity.UserNotification;
-import com.m3pro.groundflipbebatch.enums.NotificationCategory;
 import com.m3pro.groundflipbebatch.enums.PushKind;
 import com.m3pro.groundflipbebatch.enums.PushTarget;
-import com.m3pro.groundflipbebatch.repository.NotificationRepository;
-import com.m3pro.groundflipbebatch.repository.UserNotificationRepository;
-import com.m3pro.groundflipbebatch.repository.UserRepository;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,63 +13,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationService {
-	private final UserNotificationRepository userNotificationRepository;
-	private final NotificationRepository notificationRepository;
-	private final UserRepository userRepository;
 	private final FcmService fcmService;
-	private final AnnouncementService announcementService;
+	private final NotificationManager notificationManager;
 
-
-	@Transactional
 	public void createAchievementNotification(Long userId, Achievement achievement) {
-		Notification notification = notificationRepository.save(Notification.builder()
-			.title(achievement.getName() + " 획득!")
-			.category(NotificationCategory.ACHIEVEMENT.getCategoryName())
-			.categoryId(NotificationCategory.ACHIEVEMENT.getCategoryId())
-			.contentId(achievement.getId())
-			.build()
-		);
-		userNotificationRepository.save(UserNotification.builder()
-			.userId(userId)
-			.notification(notification)
-			.build());
+		notificationManager.createAchievementNotification(userId, achievement);
 		fcmService.sendNotificationToUser(achievement.getName() + " 획득!", achievement.getName() + " 획득하였습니다!", userId);
 	}
 
-	@Transactional
 	public void createAnnouncementNotification(String title, String contents, String message) {
-		Long announcementId = announcementService.createAnnouncement(title, contents);
-		Notification notification = notificationRepository.save(Notification.builder()
-			.title(title)
-			.category(NotificationCategory.ANNOUNCEMENT.getCategoryName())
-			.categoryId(NotificationCategory.ANNOUNCEMENT.getCategoryId())
-			.contentId(announcementId)
-			.build()
-		);
-		createNotificationToAllUsers(notification);
-
+		notificationManager.createAnnouncementNotification(title, contents);
 		fcmService.sendNotificationToAllUsers(title, message, PushTarget.ALL, PushKind.SERVICE);
-	}
-
-	private void createNotificationToAllUsers(Notification notification) {
-		int page = 0;
-		int pageSize = 500;
-
-		Pageable pageable = PageRequest.of(page, pageSize);
-		Page<User> userPage;
-		do {
-			userPage = userRepository.findAll(pageable);
-			List<UserNotification> userNotifications = userPage.getContent().stream()
-				.map(user -> UserNotification.builder()
-					.notification(notification)
-					.userId(user.getId())
-					.build())
-				.collect(Collectors.toList());
-
-			userNotificationRepository.saveAll(userNotifications);
-			userNotificationRepository.flush(); // 캐시 초기화
-
-			pageable = pageable.next(); // 다음 페이지로 이동
-		} while (userPage.hasNext());
 	}
 }


### PR DESCRIPTION
# 작업 내용*
- 전체 유저에게 푸시를 발송하는 로직 최적화
- 공지사항 공지시 DB 에 먼저 데이터 저장 후 푸시 알림을 전송하도록 수정

# 고민한 내용*
## FCM 전체 알림 최적화
### 기존의 문제 상황
약 1000명의 유저에게 푸시 알림을 발송하는데 약 4분 정도의 시간이 걸렸다. 1000명에 4분은 매우 느림. 처음 푸시 알림을 받은 사용자와 마지막에 받은 사용자 사이에 4분의 텀이 존재한다.
#### 기존 코드
```java
fcmTokens.forEach(fcmToken -> {
    try {
        log.info(fcmToken.getId().toString());
        sendMessage(title, body, fcmToken.getToken());
    } catch(FirebaseMessagingException e) {
        if (isInvalidTokenError(e)) {
            failedTokensId.add(fcmToken.getId());
            log.warn("Failed to send notification to [{}]: {}", fcmToken.getUser().getId(), fcmToken.getToken());
        }
    }
});
```
기존 코드를 살펴보면 단순히 유저의 수 만큼 반복하여 동기방식으로 전송한다.

### 개선 방식
현재 우리가 사용했던 전송 메소드는 `FirebaseMessaging` 의 `send` 메소드이다. `FirebaseMessaging` 를 살펴보면 여러 메소드가 존재한다.
- `send`
- `sendEach`
- `sendEachForMulticast`
- `sendAll`

이중에서 `sendEachForMulticast` 를 사용하여 개선하였다.

`sendEach` 는 `sendEachForMulticast` 와 내부 동작 방식은 같고 파라미터를 받는 방식만 다른 메소드이기 때문에 사용하지 않았다. 또한 `sendAll` 은 depreciate 되었기 때문에 사용하지 않았다.

#### 빠른 이유
`sendEachForMulticast` 방식은 내부적으로 여러개의 푸시 메시지를 비동기 방식으로 전송하기 때문에 여러번 `send`를 호출하는 것 보다 빠르다. batch 사이즈는 최대 500 까지 가능하지만 테스트 해본 결과 100일때 가장 안정적으로 동작하기 때문에 batchSize 는 100으로 설정하였다.

사실, `sendAsync` 라는 비동기 `send` 메서드가 있다. 이 메서드를 사용하여 모든 유저를 한번에 비동기 처리를 하면 1초 정도로 매우 빠르게 처리가 되지만, 한번에 많은 양을 동시에 비동기 처리 하기에는 현재의 우리 서버 스펙에서는 힘들 것 같아 배치 처리로 최종 결정하였다.

#### 결과
약 1000명의 유저에게 푸시 알림을 발송 할 시, 4분 에서 약 4초로 기존에 비해 10% 수준으로 줄일 수 있었다.

## 공지 사항 알림 개선
기존에는 푸시 알림이 모두 전송된 후 트랜잭션이 commit 되었다. 그러다보니 알림을 먼저 받은 유저는 공지내용을 확인하려 해도 확인하지 못하는 문제가 있었다.

### 개선 방법
DB 에 저장되는 로직만 트랜잭션으로 묶고 알림이 전송되는 부분은 트랜잭션 밖으로 빼서 해결하였다.

